### PR TITLE
FIX: Don't assume SS4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
 		"issues": "https://github.com/tractorcow/silverstripe-sitemap2/issues"
 	},
 	"require": {
-		"silverstripe/framework": ">=3.1",
-		"silverstripe/cms": ">=3.1",
+		"silverstripe/framework": "^3.1",
+		"silverstripe/cms": "^3.1",
 		"composer/installers": "*"
 	},
 	"extra": {


### PR DESCRIPTION
Major versions won't automatically work, and so I've amended the composer requirements
not to allow SS4.

This will also ensure that addons.silverstripe.org correctly reports which modules
work with SS4.